### PR TITLE
Overestimate Max Height

### DIFF
--- a/clamp.js
+++ b/clamp.js
@@ -80,7 +80,7 @@
          */
         function getMaxHeight(clmp) {
             var lineHeight = getLineHeight(element);
-            return lineHeight * clmp;
+            return  Math.ceil(lineHeight * clmp);
         }
 
         /**
@@ -91,9 +91,9 @@
             if (lh == 'normal') {
                 // Normal line heights vary from browser to browser. The spec recommends
                 // a value between 1.0 and 1.2 of the font size. Using 1.1 to split the diff.
-                lh = parseInt(computeStyle(elem, 'font-size'), 10) * 1.2;
+                lh = parseFloat(computeStyle(elem, 'font-size')) * 1.2;
             }
-            return parseInt(lh, 10);
+            return parseFloat(lh);
         }
 
         /**


### PR DESCRIPTION
Element height gets rounded up on firefox, so rounding up the desired max height is preferable.
